### PR TITLE
Respect action in createLocation. Fixes #17.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,8 +77,8 @@ export default function useNamedRoutes(createHistory) {
       return history.createHref(resolveLocation(location));
     }
 
-    function createLocation(location) {
-      return history.createLocation(resolveLocation(location));
+    function createLocation(location, ...args) {
+      return history.createLocation(resolveLocation(location), ...args);
     }
 
     return {


### PR DESCRIPTION
Before this change, the
[createLocation](https://github.com/taion/use-named-routes/blob/d3348ee761e369263cde6f4c44f7904f47f0d04c/src/index.js#L81)
function ignored the action parameter from
[createLocationFromRedirectInfo](https://github.com/reactjs/react-router/blob/8707d05b00273590e4d054771b8ae7ae9ad312e3/modules/createTransitionManager.js#L47)
which broke the behavior of IndexRedirect.
