### PR TITLE
Support history v2-v3 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/taion/use-named-routes#readme",
   "peerDependencies": {
-    "history": "^2.0.0",
+    "history": ">=2.0.0 <4",
     "react-router": "^2.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   },
   "homepage": "https://github.com/taion/use-named-routes#readme",
   "peerDependencies": {
-    "history": ">=2.0.0 <4",
-    "react-router": "^2.0.0"
+    "history": "^2.0.0 || ^3.0.0",
+    "react-router": "^2.0.0 || ^3.0.0-0"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",


### PR DESCRIPTION
Update peer dependency `history` to versions 2.x until 3.x. Apparently will not work with `history@4` since it removed the concept of history enhancers.
